### PR TITLE
Add moduleNameMapper option to jest config

### DIFF
--- a/template/[test]jest.config.json.ejs
+++ b/template/[test]jest.config.json.ejs
@@ -2,6 +2,9 @@
   "roots": ["src", "test"]<% if (typescript) { %>,
   "preset": "ts-jest"<% } %>,
   "testMatch": ["<rootDir>/test/**/*"],
+  "moduleNameMapper": {
+    "^~/(.+)$": "<rootDir>/src/$1"
+  },
   "collectCoverage": true,
   "collectCoverageFrom": ["<rootDir>/src/**/*"],
   "coverageReporters": ["lcov"],


### PR DESCRIPTION
This option make jest more consistent with babel/typescript path alias.